### PR TITLE
Prevent presentation of child fields

### DIFF
--- a/common.js
+++ b/common.js
@@ -139,6 +139,10 @@ function extract(o,parent,seen,depth,callback){
 function schemaToArray(schema,depth,lines,trim) {
 
 	let seen = [];
+  // this is to prevent child fields being displayed in the docs
+  if (depth > 0) {
+    return;
+  }
 	extract(schema,'',seen,depth,function(obj,depth,required,oldRef){
 		let prefix = '»'.repeat(depth);
         for (let p in obj) {


### PR DESCRIPTION
The standard Widdershins presentation of child fields involves preprending
chevrons, and user testing of the GOV.UK Content API documentation showed that
users found this confusing. We modify the `common.js` file to return when
trying to process fields below the parent field, thus preventing them from
being displayed in the documentation.

https://trello.com/c/tsv24HQ8/1068-05-documentation-improvements-based-on-initial-feedback