### PR TITLE
Revert "Remove x-old-ref fields"

### DIFF
--- a/common.js
+++ b/common.js
@@ -30,7 +30,7 @@ function dereference(obj, circles, api, cloneFunc) {
     while (obj && obj["$ref"] && !circular.isCircular(circles, obj.$ref)) {
 		var oRef = obj.$ref;
         obj = cloneFunc(jptr.jptr(api, obj["$ref"]));
-		//obj["x-old-ref"] = oRef;
+		obj["x-old-ref"] = oRef;
     }
     var changes = 1;
     while (changes > 0) {
@@ -38,7 +38,7 @@ function dereference(obj, circles, api, cloneFunc) {
         recurse(obj, {}, function (obj, state) {
             if ((state.key === '$ref') && (typeof obj === 'string') && (!circular.isCircular(circles, obj))) {
 				state.parents[state.parents.length - 2][state.keys[state.keys.length - 2]] = cloneFunc(jptr.jptr(api, obj));
-                //state.parents[state.parents.length - 2][state.keys[state.keys.length - 2]]["x-old-ref"] = obj;
+                state.parents[state.parents.length - 2][state.keys[state.keys.length - 2]]["x-old-ref"] = obj;
 				delete state.parent["$ref"]; // just in case
                 changes++;
             }


### PR DESCRIPTION
This reverts commit 4dd318810e9dcdcb7ea5be8239fec13700ffaf7a, which breaks documentation for responses where the response is an array of some schema.

@thomasleese doesn't remember why we originally made this change. It's possible we might need to fix the original problem in a different way, but I think we should roll this back as it limits what you can put in an OpenAPI spec.

Vanilla widdershins renders a table like this:

| name | type | required | description |
| --------|-----|--------| ---------------|
| *anonymous* | [MyThing] | false | Description of my response |

Followed by some child fields, which we intentionally strip out
(see https://github.com/alphagov/widdershins/pull/4)

Despite this table being mostly indecipherable nonsense, it does at
least have a working hyperlink to the actual `MyThing` schema
documentation.

The alphagov fork currently breaks this link, and it renders the type as
`[object]`, thus completely destroying the illusion that there is any
meaningful information in this table.